### PR TITLE
Add composer.json for easy composer install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "systopia/de.systopia.xdedupe",
+    "description": "CiviCRM Extended Dedupe Tools",
+    "type": "civicrm-ext",
+    "license": "AGPL-3.0"
+}


### PR DESCRIPTION
Hi xdedupe team,

I would like to install airmail using composer. Having a composer.json file in this repo would allow me to install the extension like this:

```json
{
    "type": "vcs",
    "url": "https://github.com/systopia/de.systopia.xdedupe.git"
}
```

rather than defining a package definition like this:

```
        {
            "type": "package",
            "package": {
                "name": "systopia/de.systopia.xdedupe",
                "version": "1.3.0",
                "type": "civicrm-ext",
                "source": {
                    "url": "https://github.com/systopia/de.systopia.xdedupe.git",
                    "type": "git",
                    "reference": "1.3.0"
                }
            }
        },
```

It also allows for updating packages using the releases feature in github rather than having to manually update packages.

It's based on the [CiviCRM's Composer guide](https://civicrm.org/blog/bradleyt/composer-installers-and-civicrm)

Thanks for your consideration!