### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Xdedupe/Configuration.php
+++ b/CRM/Xdedupe/Configuration.php
@@ -55,7 +55,7 @@ class CRM_Xdedupe_Configuration
 
         // main attributes go into $this->attributes
         foreach (self::$main_attributes as $attribute_name => $attribute_type) {
-            $this->attributes[$attribute_name] = CRM_Utils_Array::value($attribute_name, $data);
+            $this->attributes[$attribute_name] = $data[$attribute_name] ?? NULL;
         }
 
         // extract the stats
@@ -315,7 +315,7 @@ class CRM_Xdedupe_Configuration
      */
     public function getAttribute($attribute_name)
     {
-        return CRM_Utils_Array::value($attribute_name, $this->attributes);
+        return $this->attributes[$attribute_name] ?? NULL;
     }
 
     /**

--- a/CRM/Xdedupe/Form/ControlRoom.php
+++ b/CRM/Xdedupe/Form/ControlRoom.php
@@ -728,7 +728,7 @@ class CRM_Xdedupe_Form_ControlRoom extends CRM_Core_Form
         // join picker fields
         $values['main_contact'] = [];
         foreach (range(1, self::PICKER_COUNT) as $i) {
-            $picker = CRM_Utils_Array::value("main_contact_{$i}", $values);
+            $picker = $values["main_contact_{$i}"] ?? NULL;
             if ($picker) {
                 $values['main_contact'][] = $picker;
             }
@@ -784,7 +784,7 @@ class CRM_Xdedupe_Form_ControlRoom extends CRM_Core_Form
         // compare other
         $config = $configuration->getConfig();
         foreach ($config as $key => $stored_value) {
-            $current_value = CRM_Utils_Array::value($key, $current_values);
+            $current_value = $current_values[$key] ?? NULL;
             if (json_encode($current_value) != json_encode($stored_value)) {
                 return true;
             }

--- a/CRM/Xdedupe/Resolver/AttributeCleanup.php
+++ b/CRM/Xdedupe/Resolver/AttributeCleanup.php
@@ -81,7 +81,7 @@ abstract class CRM_Xdedupe_Resolver_AttributeCleanup extends CRM_Xdedupe_Resolve
         $contact_ids = array_merge([$main_contact_id], $other_contact_ids);
         foreach ($contact_ids as $contact_id) {
             $contact   = $this->getContext()->getContact($contact_id);
-            $new_value = $old_value = CRM_Utils_Array::value($this->attribute_name, $contact);
+            $new_value = $old_value = $contact[$this->attribute_name] ?? NULL;
             foreach ($this->regular_expressions as $search_replace) {
                 $new_value = preg_replace($search_replace[0], $search_replace[1], $new_value);
             }

--- a/CRM/Xdedupe/Resolver/DetailMover.php
+++ b/CRM/Xdedupe/Resolver/DetailMover.php
@@ -103,8 +103,8 @@ abstract class CRM_Xdedupe_Resolver_DetailMover extends CRM_Xdedupe_Resolver
     {
         $attributes = $this->getFieldList();
         foreach ($attributes as $attribute) {
-            $value1 = CRM_Utils_Array::value($attribute, $detail1);
-            $value2 = CRM_Utils_Array::value($attribute, $detail2);
+            $value1 = $detail1[$attribute] ?? NULL;
+            $value2 = $detail2[$attribute] ?? NULL;
             if ($value1 != $value2) {
                 return false;
             }

--- a/CRM/Xdedupe/Resolver/SimpleAttribute.php
+++ b/CRM/Xdedupe/Resolver/SimpleAttribute.php
@@ -186,7 +186,7 @@ abstract class CRM_Xdedupe_Resolver_SimpleAttribute extends CRM_Xdedupe_Resolver
         $values = [];
         foreach ($contact_ids as $contact_id) {
             $contact = $this->getContext()->getContact($contact_id);
-            $value   = CRM_Utils_Array::value($this->attribute_name, $contact);
+            $value   = $contact[$this->attribute_name] ?? NULL;
             if (!$this->isValueEmpty($value)) {
                 $values[$value][] = $contact_id;
             }

--- a/api/v3/Xdedupe/Run.php
+++ b/api/v3/Xdedupe/Run.php
@@ -79,7 +79,7 @@ function civicrm_api3_xdedupe_run($params)
     }
 
     $all_stats   = [];
-    $merge_limit = CRM_Utils_Array::value('merge_limit', $params);
+    $merge_limit = $params['merge_limit'] ?? NULL;
     foreach ($configs_to_run as $config_to_run) {
         try {
             $all_stats[] = $config_to_run->run($params, $merge_limit);


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.