### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Xdedupe/Resolver/SimpleAttribute.php
+++ b/CRM/Xdedupe/Resolver/SimpleAttribute.php
@@ -211,7 +211,7 @@ abstract class CRM_Xdedupe_Resolver_SimpleAttribute extends CRM_Xdedupe_Resolver
      * @param $contact_ids array  contact IDs
      *
      * @return TRUE if a change was performed
-     * @throws CiviCRM_API3_Exception
+     * @throws CRM_Core_Exception
      */
     protected function unsetValueForContacts($contact_ids)
     {

--- a/api/v3/Xdedupe/Merge.php
+++ b/api/v3/Xdedupe/Merge.php
@@ -72,7 +72,7 @@ function _civicrm_api3_xdedupe_merge_spec(&$spec)
  *
  * @param array $params see specs
  * @return array result merge result
- * @throws CiviCRM_API3_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_xdedupe_merge($params)
 {
@@ -94,7 +94,7 @@ function civicrm_api3_xdedupe_merge($params)
         $null = null;
         return civicrm_api3_create_success([], $params, 'Xdedupe', 'merge', $null, $result);
     } catch (Exception $ex) {
-        throw new CiviCRM_API3_Exception($ex->getMessage(), $ex->getCode());
+        throw new CRM_Core_Exception($ex->getMessage(), $ex->getCode());
     }
 }
 

--- a/api/v3/Xdedupe/Run.php
+++ b/api/v3/Xdedupe/Run.php
@@ -53,7 +53,7 @@ function _civicrm_api3_xdedupe_run_spec(&$spec)
  *
  * @param array $params see specs
  * @return array result merge result
- * @throws CiviCRM_API3_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_xdedupe_run($params)
 {


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.