### PR TITLE
Fix (workaround) for #38 infinite loop due to uncommitted transactions

### DIFF
--- a/CRM/Xdedupe/Merge.php
+++ b/CRM/Xdedupe/Merge.php
@@ -332,6 +332,11 @@ class CRM_Xdedupe_Merge
         $this->unloadContact($main_contact_id);
         $this->unloadContact($other_contact_id);
 
+        // See https://github.com/systopia/de.systopia.xdedupe/issues/38
+        // Under certain situations the transaction is not committed, so
+        // this explicit call helps prevent an infinite loop.
+        $transaction->commit();
+
         return $merge_succeeded;
     }
 


### PR DESCRIPTION
I've included the fix because although I'd like to fully understand the problem, this does fix it, and explicitly committing a transaction should not do anything bad.

See #38 